### PR TITLE
Issue/8

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The following options are available:
 | -id                | string      | The technical id of the code system. Required if using PUT to upload the resource to a FHIR server. |
 | -identifier        | string      | Comma-separated list of additional business identifiers. Each business identifer has the format [system]|[value]. |
 | -includeDeprecated | boolean     | Include all OWL classes, including deprecated ones. |
+| -jurisdiction      | string      | Comma-separated list of jurisdictions for the codesystem. Each jurisdiction must have the format [code\|system\|display], with values retrieved from the [FHIR Jurisdiction ValueSet](https://hl7.org/fhir/valueset-jurisdiction.html). |
 | -labelsToExclude   | string      | Comma-separated list of class labels to exclude. |
 | -language          | string      | The language of the content. This is a code from the [FHIR Common Languages value set](https://www.hl7.org/fhir/valueset-languages.html). |
 | - mainNs           | string      | Comma-separated list of namespace prefixes that determine which classes are part of the main ontology. |

--- a/README.md
+++ b/README.md
@@ -67,12 +67,12 @@ The following options are available:
 | -descriptionProp   | string      | Comma-separated list of OWL annotation properties that contain the code system description. |
 | -experimental      | boolean     | Indicates if the code system is for testing purposes or real usage. |
 | -help              | none        | Print the help message. |
-| -heirarchyMeaning  | string      | The meaning of the hierarchy of concepts as represented in this resource. Valid values are *grouped-by*, *is-a*, *part-of*, and *classified-with*.  Default is *is-a*. | 
+| -hierarchyMeaning  | string      | The meaning of the hierarchy of concepts as represented in this resource. Valid values are *grouped-by*, *is-a*, *part-of*, and *classified-with*.  Default is *is-a*. | 
 | -i                 | string      | The input OWL file. |
 | -id                | string      | The technical id of the code system. Required if using PUT to upload the resource to a FHIR server. |
 | -identifier        | string      | Comma-separated list of additional business identifiers. Each business identifer has the format [system]\|[value]. |
 | -includeDeprecated | boolean     | Include all OWL classes, including deprecated ones. |
-| -jurisdiction      | string      | Comma-separated list of jurisdictions for the codesystem. Each jurisdiction must have the format [code\|system\|display], with values retrieved from the [FHIR Jurisdiction ValueSet](https://hl7.org/fhir/valueset-jurisdiction.html). |
+| -jurisdiction      | string      | Comma-separated list of jurisdictions for the codesystem. Each jurisdiction must have the format [system\|code\|display], with values retrieved from the [FHIR Jurisdiction ValueSet](https://hl7.org/fhir/valueset-jurisdiction.html). |
 | -labelsToExclude   | string      | Comma-separated list of class labels to exclude. |
 | -language          | string      | The language of the content. This is a code from the [FHIR Common Languages value set](https://www.hl7.org/fhir/valueset-languages.html). |
 | - mainNs           | string      | Comma-separated list of namespace prefixes that determine which classes are part of the main ontology. |

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The following options are available:
 | -c                 | string      | Indicates which annotation property contains the concepts' codes. If the value is not set, then the IRI of the class is used. If the class is imported then the full IRI is used. If the class is defined in the ontology then the short form is used. |
 | -codeReplace       | string      | Two strings separated by a comma. Replaces the first string with the second string in all local codes. |
 | -compositional     | boolean     | Flag to indicate if the code system defines a post-coordination grammar. |
-| -contact           | string      | Comma-separated list of contact details for the publisher. Each contact detail has the format [name|system|value], where system has the following possible values: *phone*, *fax*, *email*, *pager*, *url*, *sms* or *other*. |
+| -contact           | string      | Comma-separated list of contact details for the publisher. Each contact detail has the format [name\|system\|value], where system has the following possible values: *phone*, *fax*, *email*, *pager*, *url*, *sms* or *other*. |
 | -content           | string      | The extent of the content in this resource. Valid values are *not-present*, *example*, *fragment*, *complete* and *supplement*. Defaults to *complete*. The actual value does not affect the output of the transformation. |
 | -copyright         | string      | A copyright statement about the code system. |
 | -d                 | string      | Indicates which annotation property contains the concepts' displays. Default is RDFS:label. |
@@ -70,7 +70,7 @@ The following options are available:
 | -heirarchyMeaning  | string      | The meaning of the hierarchy of concepts as represented in this resource. Valid values are *grouped-by*, *is-a*, *part-of*, and *classified-with*.  Default is *is-a*. | 
 | -i                 | string      | The input OWL file. |
 | -id                | string      | The technical id of the code system. Required if using PUT to upload the resource to a FHIR server. |
-| -identifier        | string      | Comma-separated list of additional business identifiers. Each business identifer has the format [system]|[value]. |
+| -identifier        | string      | Comma-separated list of additional business identifiers. Each business identifer has the format [system]\|[value]. |
 | -includeDeprecated | boolean     | Include all OWL classes, including deprecated ones. |
 | -jurisdiction      | string      | Comma-separated list of jurisdictions for the codesystem. Each jurisdiction must have the format [code\|system\|display], with values retrieved from the [FHIR Jurisdiction ValueSet](https://hl7.org/fhir/valueset-jurisdiction.html). |
 | -labelsToExclude   | string      | Comma-separated list of class labels to exclude. |

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The following options are available:
 | -descriptionProp   | string      | Comma-separated list of OWL annotation properties that contain the code system description. |
 | -experimental      | boolean     | Indicates if the code system is for testing purposes or real usage. |
 | -help              | none        | Print the help message. |
+| -heirarchyMeaning  | string      | The meaning of the hierarchy of concepts as represented in this resource. Valid values are *grouped-by*, *is-a*, *part-of*, and *classified-with*.  Default is *is-a*. | 
 | -i                 | string      | The input OWL file. |
 | -id                | string      | The technical id of the code system. Required if using PUT to upload the resource to a FHIR server. |
 | -identifier        | string      | Comma-separated list of additional business identifiers. Each business identifer has the format [system]|[value]. |

--- a/src/main/java/au/csiro/fhir/owl/Application.java
+++ b/src/main/java/au/csiro/fhir/owl/Application.java
@@ -56,7 +56,7 @@ public class Application implements CommandLineRunner {
   
   /**
    * Returns a GSON bean, with a custom serialiser for {@link Bundle}s.
-   * 
+   *
    * @return A bean that contains the GSON instance.
    */
   @Bean
@@ -68,7 +68,7 @@ public class Application implements CommandLineRunner {
   
   /**
    * Main method.
-   * 
+   *
    * @param args Arguments.
    */
   public static void main(String[] args) {
@@ -162,6 +162,10 @@ public class Application implements CommandLineRunner {
     
     options.addOption("experimental", false, "Indicates if the code system is for testing "
         + "purposes or real usage.");
+    
+    options.addOption("heirarchyMeaning", true, "The meaning of the hierarchy of concepts as "
+        + "represented in this resource. Valid values are *grouped-by*, *is-a*, *part-of*, and *classified-with*.  "
+        + "Default is *is-a*.");
     
     options.addOption(
         Option.builder("i")
@@ -272,7 +276,7 @@ public class Application implements CommandLineRunner {
           fhirOwlService.transform(csp, cp);
         }
       } catch (Throwable t) {
-        System.out.println("There was a problem transforming the OWL file into FHIR: " 
+        System.out.println("There was a problem transforming the OWL file into FHIR: "
             + t.getLocalizedMessage());
         t.printStackTrace();
       }
@@ -415,6 +419,11 @@ public class Application implements CommandLineRunner {
     val = line.getOptionValue("purpose");
     if (val != null) {
       res.setPurpose(val);
+    }
+    
+    val = line.getOptionValue("heirarchyMeaning");
+    if (val != null) {
+      res.setHeirarchyMeaning(val);
     }
     
     val = line.getOptionValue("copyright");

--- a/src/main/java/au/csiro/fhir/owl/Application.java
+++ b/src/main/java/au/csiro/fhir/owl/Application.java
@@ -182,6 +182,10 @@ public class Application implements CommandLineRunner {
     options.addOption("identifier", true, "Comma-separated list of additional business "
         + "identifiers. Each business identifer has the format [system]|[value].");
     
+    options.addOption("jurisdiction", true, "Comma-separated list of jurisdictions for the codesystem. "
+        + "Each jurisdiction must have the format [code|system|display], with values retrieved from the "
+        + "[FHIR Jurisdiction ValueSet](https://hl7.org/fhir/valueset-jurisdiction.html)");
+    
     options.addOption("includeDeprecated", false, "Include all OWL classes, including deprecated "
         + "ones.");
     
@@ -414,6 +418,11 @@ public class Application implements CommandLineRunner {
     val = line.getOptionValue("descriptionProp");
     if (val != null) {
       res.setDescriptionProps(val);
+    }
+    
+    val = line.getOptionValue("jurisdiction");
+    if (val != null) {
+      res.setJurisdiction(val);
     }
 
     val = line.getOptionValue("purpose");

--- a/src/main/java/au/csiro/fhir/owl/Application.java
+++ b/src/main/java/au/csiro/fhir/owl/Application.java
@@ -163,7 +163,7 @@ public class Application implements CommandLineRunner {
     options.addOption("experimental", false, "Indicates if the code system is for testing "
         + "purposes or real usage.");
     
-    options.addOption("heirarchyMeaning", true, "The meaning of the hierarchy of concepts as "
+    options.addOption("hierarchyMeaning", true, "The meaning of the hierarchy of concepts as "
         + "represented in this resource. Valid values are *grouped-by*, *is-a*, *part-of*, and *classified-with*.  "
         + "Default is *is-a*.");
     
@@ -439,9 +439,9 @@ public class Application implements CommandLineRunner {
       res.setPurpose(val);
     }
     
-    val = line.getOptionValue("heirarchyMeaning");
+    val = line.getOptionValue("hierarchyMeaning");
     if (val != null) {
-      res.setHeirarchyMeaning(val);
+      res.setHierarchyMeaning(val);
     }
     
     val = line.getOptionValue("copyright");

--- a/src/main/java/au/csiro/fhir/owl/Application.java
+++ b/src/main/java/au/csiro/fhir/owl/Application.java
@@ -229,7 +229,10 @@ public class Application implements CommandLineRunner {
         + "retired and unknown");
     
     options.addOption("t", "title", true, "A human-friendly name for the code system.");
-    
+  
+    options.addOption("test", false, "Whether to keep the spring application up for the sake of allowing " 
+        + "assertion test cases to be run after the transform process finishes");
+  
     options.addOption("url", true, "Canonical identifier of the code system. If this option is"
         + " not specified then the ontology’s IRI will be used. If the ontology has no IRI then "
         + "the transformation fails.");
@@ -279,19 +282,25 @@ public class Application implements CommandLineRunner {
         } else {
           fhirOwlService.transform(csp, cp);
         }
+        
+//   Only used to keep the application context up for the sake of allowing assertions in tests.  
+//   Finishing the test cases exits the process, so there shouldn't be a case where this is left open indefinitely.
+        if (!line.hasOption("test")) {
+          exit(0);
+        }
       } catch (Throwable t) {
         System.out.println("There was a problem transforming the OWL file into FHIR: "
             + t.getLocalizedMessage());
         t.printStackTrace();
+        exit(0);
       }
       
     } catch (ParseException exp) {
       // oops, something went wrong
       System.out.println(exp.getMessage());
       printUsage(options);
+      exit(0);
     }
-    
-    exit(0);
   }
   
   private ConceptProperties loadConceptProperties(CommandLine line) {

--- a/src/main/java/au/csiro/fhir/owl/CodeSystemProperties.java
+++ b/src/main/java/au/csiro/fhir/owl/CodeSystemProperties.java
@@ -48,7 +48,7 @@ public class CodeSystemProperties extends OwlProperties {
   private String description = null;
   private final List<String> descriptionProps = new ArrayList<>();
   private String purpose = null;
-  private String heirarchyMeaning = null;
+  private String hierarchyMeaning = null;
   private String copyright = null;
   private String valueSet = null;
   private boolean compositional = false;
@@ -220,10 +220,10 @@ public class CodeSystemProperties extends OwlProperties {
       String[] parts = jd.split("[|]");
       if (parts.length != 3) {
         throw new InvalidPropertyException("Invalid jurisdiction '" + jd
-                                               + "'. Valid format is [code|system|display] from https://hl7.org/fhir/valueset-jurisdiction.html.");
+                                               + "'. Valid format is [system|code|display] from https://hl7.org/fhir/valueset-jurisdiction.html.");
       }
       CodeableConcept jurisdiction = new CodeableConcept();
-      jurisdiction.addCoding(new Coding(parts[1], parts[0], parts[2]));
+      jurisdiction.addCoding(new Coding(parts[0], parts[1], parts[2]));
       jurisdictions.add(jurisdiction);
     }
   }
@@ -501,21 +501,21 @@ public class CodeSystemProperties extends OwlProperties {
   }
   
   /**
-   * Returns the heirarchyMeaning.
+   * Returns the hierarchyMeaning.
    *
-   * @return the heirarchyMeaning
+   * @return the hierarchyMeaning
    */
-  public String getHeirarchyMeaning() {
-    return heirarchyMeaning;
+  public String getHierarchyMeaning() {
+    return hierarchyMeaning;
   }
   
   /**
-   * Sets the heirarchyMeaning.
+   * Sets the hierarchyMeaning.
    *
-   * @param heirarchyMeaning the heirarchyMeaning to set
+   * @param hierarchyMeaning the hierarchyMeaning to set
    */
-  public void setHeirarchyMeaning(String heirarchyMeaning) {
-    this.heirarchyMeaning = heirarchyMeaning;
+  public void setHierarchyMeaning(String hierarchyMeaning) {
+    this.hierarchyMeaning = hierarchyMeaning;
   }
 
   /**

--- a/src/main/java/au/csiro/fhir/owl/CodeSystemProperties.java
+++ b/src/main/java/au/csiro/fhir/owl/CodeSystemProperties.java
@@ -10,7 +10,10 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;
 
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.ContactDetail;
+import org.hl7.fhir.r4.model.ContactPoint;
 import org.hl7.fhir.r4.model.Identifier;
 import org.semanticweb.owlapi.model.OWLAnnotationProperty;
 import org.semanticweb.owlapi.model.OWLDataFactory;
@@ -41,6 +44,7 @@ public class CodeSystemProperties extends OwlProperties {
   private String publisher = null;
   private final List<String> publisherProps = new ArrayList<>();
   private final List<ContactDetail> contacts = new ArrayList<>();
+  private final List<CodeableConcept> jurisdictions = new ArrayList<>();
   private String description = null;
   private final List<String> descriptionProps = new ArrayList<>();
   private String purpose = null;
@@ -196,7 +200,36 @@ public class CodeSystemProperties extends OwlProperties {
       }
     }
   }
-
+  
+  /**
+   * Parses the arguments of the jurisdiction parameter.
+   *
+   * @param jds The string that contains the jurisdiction information.
+   * @throws InvalidPropertyException If the string is not well formed.
+   */
+  public void setJurisdiction(String jds) {
+    for (String jd : jds.split("[,]")) {
+      String[] parts = jd.split("[|]");
+      if (parts.length != 3) {
+        throw new InvalidPropertyException("Invalid jurisdiction '" + jd
+                                               + "'. Valid format is [code|system|display] from https://hl7.org/fhir/valueset-jurisdiction.html.");
+      }
+      CodeableConcept jurisdiction = new CodeableConcept();
+      jurisdiction.addCoding(new Coding(parts[1], parts[0], parts[2]));
+      jurisdictions.add(jurisdiction);
+    }
+  }
+  
+  /**
+   * Returns the jurisdictions property.
+   *
+   * @return the jurisdictions
+   */
+  public List<CodeableConcept> getJurisdictions() {
+    return jurisdictions;
+  }
+  
+  
   /**
    * Returns the content property.
    *

--- a/src/main/java/au/csiro/fhir/owl/CodeSystemProperties.java
+++ b/src/main/java/au/csiro/fhir/owl/CodeSystemProperties.java
@@ -198,6 +198,14 @@ public class CodeSystemProperties extends OwlProperties {
         throw new InvalidPropertyException("Invalid system contact '" + parts[1] 
             + "'. Valid values are: " + contactSystemValues);
       }
+      
+      ContactDetail contactDetail = new ContactDetail();
+      contactDetail.setName(parts[0]);
+      ContactPoint contactPoint = new ContactPoint();
+      contactPoint.setSystem(ContactPoint.ContactPointSystem.fromCode(parts[1]));
+      contactPoint.setValue(parts[2]);
+      contactDetail.addTelecom(contactPoint);
+      contacts.add(contactDetail);
     }
   }
   

--- a/src/main/java/au/csiro/fhir/owl/CodeSystemProperties.java
+++ b/src/main/java/au/csiro/fhir/owl/CodeSystemProperties.java
@@ -44,6 +44,7 @@ public class CodeSystemProperties extends OwlProperties {
   private String description = null;
   private final List<String> descriptionProps = new ArrayList<>();
   private String purpose = null;
+  private String heirarchyMeaning = null;
   private String copyright = null;
   private String valueSet = null;
   private boolean compositional = false;
@@ -456,6 +457,24 @@ public class CodeSystemProperties extends OwlProperties {
    */
   public void setPurpose(String purpose) {
     this.purpose = purpose;
+  }
+  
+  /**
+   * Returns the heirarchyMeaning.
+   *
+   * @return the heirarchyMeaning
+   */
+  public String getHeirarchyMeaning() {
+    return heirarchyMeaning;
+  }
+  
+  /**
+   * Sets the heirarchyMeaning.
+   *
+   * @param heirarchyMeaning the heirarchyMeaning to set
+   */
+  public void setHeirarchyMeaning(String heirarchyMeaning) {
+    this.heirarchyMeaning = heirarchyMeaning;
   }
 
   /**

--- a/src/main/java/au/csiro/fhir/owl/FhirOwlService.java
+++ b/src/main/java/au/csiro/fhir/owl/FhirOwlService.java
@@ -446,9 +446,14 @@ public class FhirOwlService {
     // Value set
     final String valueset = csp.getValueSet();
     cs.setValueSet(Objects.requireNonNullElseGet(valueset, () -> createVsUrl(cs.getUrl())));
-    
-    // Hierarchy meaning - always is-a for OWL ontologies
-    cs.setHierarchyMeaning(CodeSystemHierarchyMeaning.ISA);
+  
+    // HeirarchyMeaning
+    final String heirarchyMeaning = csp.getHeirarchyMeaning();
+    if (heirarchyMeaning != null) {
+      cs.setHierarchyMeaning(CodeSystem.CodeSystemHierarchyMeaning.fromCode(heirarchyMeaning));
+    } else {
+      cs.setHierarchyMeaning(CodeSystemHierarchyMeaning.ISA);
+    }
     
     // Compositional
     cs.setCompositional(csp.isCompositional());

--- a/src/main/java/au/csiro/fhir/owl/FhirOwlService.java
+++ b/src/main/java/au/csiro/fhir/owl/FhirOwlService.java
@@ -876,7 +876,7 @@ public class FhirOwlService {
       String label = iriDisplayMap.get(iri);
       if (label != null) {
         cdc.setDisplay(label);
-      } else {
+      } else if(!cdc.hasDisplay()) {
         cdc.setDisplay(code);
       }
     } else if (preferredTerm == null) {

--- a/src/main/java/au/csiro/fhir/owl/FhirOwlService.java
+++ b/src/main/java/au/csiro/fhir/owl/FhirOwlService.java
@@ -454,10 +454,10 @@ public class FhirOwlService {
     final String valueset = csp.getValueSet();
     cs.setValueSet(Objects.requireNonNullElseGet(valueset, () -> createVsUrl(cs.getUrl())));
   
-    // HeirarchyMeaning
-    final String heirarchyMeaning = csp.getHeirarchyMeaning();
-    if (heirarchyMeaning != null) {
-      cs.setHierarchyMeaning(CodeSystem.CodeSystemHierarchyMeaning.fromCode(heirarchyMeaning));
+    // HierarchyMeaning
+    final String hierarchyMeaning = csp.getHierarchyMeaning();
+    if (hierarchyMeaning != null) {
+      cs.setHierarchyMeaning(CodeSystem.CodeSystemHierarchyMeaning.fromCode(hierarchyMeaning));
     } else {
       cs.setHierarchyMeaning(CodeSystemHierarchyMeaning.ISA);
     }

--- a/src/main/java/au/csiro/fhir/owl/FhirOwlService.java
+++ b/src/main/java/au/csiro/fhir/owl/FhirOwlService.java
@@ -37,6 +37,7 @@ import org.hl7.fhir.r4.model.CodeSystem.FilterOperator;
 import org.hl7.fhir.r4.model.CodeSystem.PropertyComponent;
 import org.hl7.fhir.r4.model.CodeSystem.PropertyType;
 import org.hl7.fhir.r4.model.CodeType;
+import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.ContactDetail;
 import org.hl7.fhir.r4.model.Enumerations.PublicationStatus;
@@ -435,6 +436,12 @@ public class FhirOwlService {
     final String purpose = csp.getPurpose();
     if (purpose != null) {
       cs.setPurpose(purpose);
+    }
+  
+    // Jurisdictions
+    final List<CodeableConcept> jurisdictions = csp.getJurisdictions();
+    if (!jurisdictions.isEmpty()) {
+      cs.setJurisdiction(jurisdictions);
     }
     
     // Copyright
@@ -900,8 +907,6 @@ public class FhirOwlService {
       // This is a synonym - but we don't know the language
       ConceptDefinitionDesignationComponent cddc = cdc.addDesignation();
       cddc.setValue(syn);
-      cddc.setUse(new Coding("http://snomed.info/sct", "900000000000013009", 
-              "Synonym (core metadata concept)"));
     }
   }
 

--- a/src/main/java/au/csiro/fhir/owl/FhirOwlService.java
+++ b/src/main/java/au/csiro/fhir/owl/FhirOwlService.java
@@ -907,6 +907,8 @@ public class FhirOwlService {
       // This is a synonym - but we don't know the language
       ConceptDefinitionDesignationComponent cddc = cdc.addDesignation();
       cddc.setValue(syn);
+      cddc.setUse(new Coding("http://snomed.info/sct", "900000000000013009", 
+              "Synonym (core metadata concept)"));
     }
   }
 

--- a/src/test/java/au/csiro/fhir/owl/MetadataDefaultsTest.java
+++ b/src/test/java/au/csiro/fhir/owl/MetadataDefaultsTest.java
@@ -1,0 +1,57 @@
+/*
+  Copyright CSIRO Australian e-Health Research Centre (http://aehrc.com). All rights reserved. Use is subject to
+  license terms and conditions.
+ */
+package au.csiro.fhir.owl;
+
+
+import static au.csiro.fhir.owl.util.ArgConstants.INPUT_FILE;
+import static au.csiro.fhir.owl.util.ArgConstants.INPUT_FLAG;
+import static au.csiro.fhir.owl.util.ArgConstants.OUTPUT_FILE;
+import static au.csiro.fhir.owl.util.ArgConstants.OUTPUT_FLAG;
+import static au.csiro.fhir.owl.util.ArgConstants.TEST_FLAG;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.IParser;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import org.hl7.fhir.r4.model.CodeSystem;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.boot.test.context.SpringBootTest;
+
+
+/**
+ * E2E tests for fhir-owl that validate the default CodeSystem metadata values when no input flags are specified.
+ */
+
+@SpringBootTest(args = {
+    TEST_FLAG,
+    INPUT_FLAG, INPUT_FILE, 
+    OUTPUT_FLAG, OUTPUT_FILE
+})
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class MetadataDefaultsTest {
+
+  private CodeSystem codeSystem;
+  
+  @BeforeAll
+  private void parseCodeSystemFromFile() throws FileNotFoundException {
+    FhirContext ctx = FhirContext.forR4();
+    File initialFile = new File(OUTPUT_FILE);
+    InputStream inputStream = new FileInputStream(initialFile);
+    IParser parser = ctx.newJsonParser();
+    codeSystem = parser.parseResource(CodeSystem.class, inputStream);
+  }
+  
+  @Test
+  public void testDefaultMetadataFieldValues() {
+    Assertions.assertEquals(codeSystem.getHierarchyMeaning(), CodeSystem.CodeSystemHierarchyMeaning.ISA);
+    Assertions.assertTrue(codeSystem.getJurisdiction().isEmpty());
+    Assertions.assertFalse(codeSystem.hasContact());
+  }
+}

--- a/src/test/java/au/csiro/fhir/owl/MetadataDefaultsTest.java
+++ b/src/test/java/au/csiro/fhir/owl/MetadataDefaultsTest.java
@@ -11,13 +11,10 @@ import static au.csiro.fhir.owl.util.ArgConstants.OUTPUT_FILE;
 import static au.csiro.fhir.owl.util.ArgConstants.OUTPUT_FLAG;
 import static au.csiro.fhir.owl.util.ArgConstants.TEST_FLAG;
 
-import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.parser.IParser;
-import java.io.File;
-import java.io.FileInputStream;
+import au.csiro.fhir.owl.util.OutputFileManager;
 import java.io.FileNotFoundException;
-import java.io.InputStream;
 import org.hl7.fhir.r4.model.CodeSystem;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -41,11 +38,7 @@ public class MetadataDefaultsTest {
   
   @BeforeAll
   private void parseCodeSystemFromFile() throws FileNotFoundException {
-    FhirContext ctx = FhirContext.forR4();
-    File initialFile = new File(OUTPUT_FILE);
-    InputStream inputStream = new FileInputStream(initialFile);
-    IParser parser = ctx.newJsonParser();
-    codeSystem = parser.parseResource(CodeSystem.class, inputStream);
+    codeSystem = OutputFileManager.getCodeSystemFromFile(OUTPUT_FILE);
   }
   
   @Test
@@ -54,4 +47,10 @@ public class MetadataDefaultsTest {
     Assertions.assertTrue(codeSystem.getJurisdiction().isEmpty());
     Assertions.assertFalse(codeSystem.hasContact());
   }
+  
+  @AfterAll
+  private void cleanup(){
+    OutputFileManager.deleteFileIfExists(OUTPUT_FILE);
+  }
+  
 }

--- a/src/test/java/au/csiro/fhir/owl/MetadataFromInputTest.java
+++ b/src/test/java/au/csiro/fhir/owl/MetadataFromInputTest.java
@@ -1,0 +1,102 @@
+/*
+  Copyright CSIRO Australian e-Health Research Centre (http://aehrc.com). All rights reserved. Use is subject to
+  license terms and conditions.
+ */
+package au.csiro.fhir.owl;
+
+
+import static au.csiro.fhir.owl.util.ArgConstants.CONTACT_EXAMPLE_WITH_EMAIL;
+import static au.csiro.fhir.owl.util.ArgConstants.CONTACT_EXAMPLE_WITH_PHONE;
+import static au.csiro.fhir.owl.util.ArgConstants.CONTACT_FLAG;
+import static au.csiro.fhir.owl.util.ArgConstants.EMAIL;
+import static au.csiro.fhir.owl.util.ArgConstants.EXAMPLE_EMAIL;
+import static au.csiro.fhir.owl.util.ArgConstants.EXAMPLE_NAME_1;
+import static au.csiro.fhir.owl.util.ArgConstants.EXAMPLE_NAME_2;
+import static au.csiro.fhir.owl.util.ArgConstants.EXAMPLE_PHONE;
+import static au.csiro.fhir.owl.util.ArgConstants.HEIRARCHY_MEANING_FLAG;
+import static au.csiro.fhir.owl.util.ArgConstants.HEIRARCHY_MEANING_GROUPED_BY;
+import static au.csiro.fhir.owl.util.ArgConstants.INPUT_FILE;
+import static au.csiro.fhir.owl.util.ArgConstants.INPUT_FLAG;
+import static au.csiro.fhir.owl.util.ArgConstants.JURISDICTION_EXAMPLE_US_ARG;
+import static au.csiro.fhir.owl.util.ArgConstants.JURISDICTION_FLAG;
+import static au.csiro.fhir.owl.util.ArgConstants.JURISDICTION_URN;
+import static au.csiro.fhir.owl.util.ArgConstants.OUTPUT_FILE;
+import static au.csiro.fhir.owl.util.ArgConstants.OUTPUT_FLAG;
+import static au.csiro.fhir.owl.util.ArgConstants.PHONE;
+import static au.csiro.fhir.owl.util.ArgConstants.TEST_FLAG;
+import static au.csiro.fhir.owl.util.ArgConstants.UNITED_STATES_OF_AMERICA;
+import static au.csiro.fhir.owl.util.ArgConstants.US;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.IParser;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.util.stream.Collectors;
+import org.hl7.fhir.r4.model.CodeSystem;
+import org.hl7.fhir.r4.model.ContactDetail;
+import org.hl7.fhir.r4.model.ContactPoint;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.boot.test.context.SpringBootTest;
+
+
+/**
+ * E2E tests for fhir-owl that validate that CodeSystem metadata values are properly represented when given as input.
+ */
+
+@SpringBootTest(args = {
+    TEST_FLAG,
+    INPUT_FLAG, INPUT_FILE, 
+    OUTPUT_FLAG, OUTPUT_FILE,
+    HEIRARCHY_MEANING_FLAG, HEIRARCHY_MEANING_GROUPED_BY,
+    JURISDICTION_FLAG, JURISDICTION_EXAMPLE_US_ARG,
+    CONTACT_FLAG, CONTACT_EXAMPLE_WITH_EMAIL+","+CONTACT_EXAMPLE_WITH_PHONE
+})
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class MetadataFromInputTest {
+
+  private CodeSystem codeSystem;
+  
+  @BeforeAll
+  private void parseCodeSystemFromFile() throws FileNotFoundException {
+    FhirContext ctx = FhirContext.forR4();
+    File initialFile = new File(OUTPUT_FILE);
+    InputStream inputStream = new FileInputStream(initialFile);
+    IParser parser = ctx.newJsonParser();
+    codeSystem = parser.parseResource(CodeSystem.class, inputStream);
+  }
+  
+  @Test
+  public void testMetadateFromArgs() {
+    Assertions.assertEquals(CodeSystem.CodeSystemHierarchyMeaning.GROUPEDBY, codeSystem.getHierarchyMeaning());
+    Assertions.assertTrue(codeSystem.getJurisdiction().size()==1);
+    Assertions.assertEquals(US, codeSystem.getJurisdiction().get(0).getCodingFirstRep().getCode());
+    Assertions.assertEquals(UNITED_STATES_OF_AMERICA, codeSystem.getJurisdiction().get(0).getCodingFirstRep().getDisplay());
+    Assertions.assertEquals(JURISDICTION_URN, codeSystem.getJurisdiction().get(0).getCodingFirstRep().getSystem());
+  }
+  
+  @Test
+  public void testContactsFromArgs() {
+    Assertions.assertTrue(codeSystem.getContact().size() == 2);
+  
+    ContactDetail contactDetail1 = codeSystem.getContact().stream()
+        .filter(contactDetail -> contactDetail.getName().equals(EXAMPLE_NAME_1))
+        .collect(Collectors.toList())
+        .get(0);
+    Assertions.assertEquals(EXAMPLE_NAME_1, contactDetail1.getName());
+    Assertions.assertEquals(ContactPoint.ContactPointSystem.fromCode(EMAIL), contactDetail1.getTelecomFirstRep().getSystem());
+    Assertions.assertEquals(EXAMPLE_EMAIL, contactDetail1.getTelecomFirstRep().getValue());
+  
+    ContactDetail contactDetail2 = codeSystem.getContact().stream()
+        .filter(contactDetail -> contactDetail.getName().equals(EXAMPLE_NAME_2))
+        .collect(Collectors.toList())
+        .get(0);
+    Assertions.assertEquals(EXAMPLE_NAME_2, contactDetail1.getName());
+    Assertions.assertEquals(ContactPoint.ContactPointSystem.fromCode(PHONE), contactDetail1.getTelecomFirstRep().getSystem());
+    Assertions.assertEquals(EXAMPLE_PHONE, contactDetail1.getTelecomFirstRep().getValue());
+  }
+}

--- a/src/test/java/au/csiro/fhir/owl/MetadataFromInputTest.java
+++ b/src/test/java/au/csiro/fhir/owl/MetadataFromInputTest.java
@@ -13,8 +13,8 @@ import static au.csiro.fhir.owl.util.ArgConstants.EXAMPLE_EMAIL;
 import static au.csiro.fhir.owl.util.ArgConstants.EXAMPLE_NAME_1;
 import static au.csiro.fhir.owl.util.ArgConstants.EXAMPLE_NAME_2;
 import static au.csiro.fhir.owl.util.ArgConstants.EXAMPLE_PHONE;
-import static au.csiro.fhir.owl.util.ArgConstants.HEIRARCHY_MEANING_FLAG;
-import static au.csiro.fhir.owl.util.ArgConstants.HEIRARCHY_MEANING_GROUPED_BY;
+import static au.csiro.fhir.owl.util.ArgConstants.HIERARCHY_MEANING_FLAG;
+import static au.csiro.fhir.owl.util.ArgConstants.HIERARCHY_MEANING_GROUPED_BY;
 import static au.csiro.fhir.owl.util.ArgConstants.INPUT_FILE;
 import static au.csiro.fhir.owl.util.ArgConstants.INPUT_FLAG;
 import static au.csiro.fhir.owl.util.ArgConstants.JURISDICTION_EXAMPLE_US_ARG;
@@ -49,7 +49,7 @@ import org.springframework.boot.test.context.SpringBootTest;
     TEST_FLAG,
     INPUT_FLAG, INPUT_FILE, 
     OUTPUT_FLAG, OUTPUT_FILE,
-    HEIRARCHY_MEANING_FLAG, HEIRARCHY_MEANING_GROUPED_BY,
+    HIERARCHY_MEANING_FLAG, HIERARCHY_MEANING_GROUPED_BY,
     JURISDICTION_FLAG, JURISDICTION_EXAMPLE_US_ARG,
     CONTACT_FLAG, CONTACT_EXAMPLE_WITH_EMAIL+","+CONTACT_EXAMPLE_WITH_PHONE
 })

--- a/src/test/java/au/csiro/fhir/owl/util/ArgConstants.java
+++ b/src/test/java/au/csiro/fhir/owl/util/ArgConstants.java
@@ -22,14 +22,14 @@ public class ArgConstants {
     public static final String CONTACT_EXAMPLE_WITH_EMAIL = EXAMPLE_NAME_1 +"|"+EMAIL+"|"+ EXAMPLE_EMAIL;
     public static final String CONTACT_EXAMPLE_WITH_PHONE = EXAMPLE_NAME_2 +"|"+PHONE+"|"+ EXAMPLE_PHONE;
     
-    public static final String HEIRARCHY_MEANING_FLAG = "-heirarchyMeaning";
-    public static final String HEIRARCHY_MEANING_GROUPED_BY = "grouped-by"; //Static value of CodeSystem.CodeSystemHierarchyMeaning.GROUPEDBY
+    public static final String HIERARCHY_MEANING_FLAG = "-hierarchyMeaning";
+    public static final String HIERARCHY_MEANING_GROUPED_BY = "grouped-by"; //Static value of CodeSystem.CodeSystemHierarchyMeaning.GROUPEDBY
     
     public static final String JURISDICTION_FLAG = "-jurisdiction";
-    public static final String US = "US";
     public static final String JURISDICTION_URN = "urn:iso:std:iso:3166";
+    public static final String US = "US";
     public static final String UNITED_STATES_OF_AMERICA = "United States of America";
-    public static final String JURISDICTION_EXAMPLE_US_ARG = US+"|"+ JURISDICTION_URN +"|"+UNITED_STATES_OF_AMERICA;
+    public static final String JURISDICTION_EXAMPLE_US_ARG = JURISDICTION_URN+"|"+US+"|"+UNITED_STATES_OF_AMERICA;
     
     
 }

--- a/src/test/java/au/csiro/fhir/owl/util/ArgConstants.java
+++ b/src/test/java/au/csiro/fhir/owl/util/ArgConstants.java
@@ -1,0 +1,35 @@
+package au.csiro.fhir.owl.util;
+
+public class ArgConstants {
+
+    //   Only used to keep the application context up for the sake of allowing assertions in tests.
+    //   Not published as an argument since it is not useful for users
+    public static final String TEST_FLAG = "-test";
+    
+    public static final String INPUT_FLAG = "-i";
+    public static final String INPUT_FILE = "src/test/resources/pizza.owl";
+    public static final String OUTPUT_FLAG = "-o";
+    public static final String OUTPUT_FILE = "src/test/resources/pizza.json";
+    
+    public static final String CONTACT_FLAG = "-contact";
+    public static final String EXAMPLE_NAME_1 = "Mr. Lorem Ipsum";
+    public static final String EXAMPLE_EMAIL = "lorem.ipsum@gmail.com";
+    public static final String EMAIL = "email";
+    public static final String EXAMPLE_NAME_2 = "Ms. Ipsum Lorem";
+    public static final String EXAMPLE_PHONE = "987-765-4321";
+    public static final String PHONE = "phone";
+    
+    public static final String CONTACT_EXAMPLE_WITH_EMAIL = EXAMPLE_NAME_1 +"|"+EMAIL+"|"+ EXAMPLE_EMAIL;
+    public static final String CONTACT_EXAMPLE_WITH_PHONE = EXAMPLE_NAME_2 +"|"+PHONE+"|"+ EXAMPLE_PHONE;
+    
+    public static final String HEIRARCHY_MEANING_FLAG = "-heirarchyMeaning";
+    public static final String HEIRARCHY_MEANING_GROUPED_BY = "grouped-by"; //Static value of CodeSystem.CodeSystemHierarchyMeaning.GROUPEDBY
+    
+    public static final String JURISDICTION_FLAG = "-jurisdiction";
+    public static final String US = "US";
+    public static final String JURISDICTION_URN = "urn:iso:std:iso:3166";
+    public static final String UNITED_STATES_OF_AMERICA = "United States of America";
+    public static final String JURISDICTION_EXAMPLE_US_ARG = US+"|"+ JURISDICTION_URN +"|"+UNITED_STATES_OF_AMERICA;
+    
+    
+}

--- a/src/test/java/au/csiro/fhir/owl/util/OutputFileManager.java
+++ b/src/test/java/au/csiro/fhir/owl/util/OutputFileManager.java
@@ -1,0 +1,28 @@
+package au.csiro.fhir.owl.util;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.IParser;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import org.hl7.fhir.r4.model.CodeSystem;
+
+public class OutputFileManager {
+    
+    public static boolean deleteFileIfExists(String filePath) {
+        File file = new File(filePath);
+        if (file.exists()) {
+            return file.delete();
+        }
+        return true;
+    }
+    
+    public static CodeSystem getCodeSystemFromFile(String filePath) throws FileNotFoundException {
+        FhirContext ctx = FhirContext.forR4();
+        File initialFile = new File(filePath);
+        InputStream inputStream = new FileInputStream(initialFile);
+        IParser parser = ctx.newJsonParser();
+        return parser.parseResource(CodeSystem.class, inputStream);
+    }
+}


### PR DESCRIPTION
See Issue/8.

Fixed contacts not being created properly.
Made heirarchyMeaning configurable.
Made jurisdiction configurable.

Added E2E tests to Validate that CodeSystem metadata added in this issue are being represented properly.
    Please see the small refactor in how the program exits in Application.java.
    If this pattern is acceptable, it will be easy to add tests for the other fields in the future using the same testing approach.

Fixed Display for base Thing being represented as the full Thing uri instead of simply "Thing"